### PR TITLE
Update the jsoup and clojure versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,4 +4,4 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.3.0"]
-                 [org.jsoup/jsoup "1.6.2"]])
+                 [org.jsoup/jsoup "1.7.1"]])


### PR DESCRIPTION
Jsoup has had a lot of improvements since version 1.6.2, this tiny change just bumps the jsoup version to 1.7.1 and the clojure version to 1.4.0.
